### PR TITLE
Some additions to shortcuts list

### DIFF
--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -871,7 +871,9 @@ patch: ${JSON.stringify(
     ${ctrl_or_cmd_name}+X:   cut selected cells
     ${ctrl_or_cmd_name}+V:   paste selected cells
 
-    The notebook file saves every time you run`
+    ${ctrl_or_cmd_name}+M:   toogle Markdown
+
+    The notebook file saves every time you run a cell.`
                 )
                 e.preventDefault()
             }

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -871,7 +871,7 @@ patch: ${JSON.stringify(
     ${ctrl_or_cmd_name}+X:   cut selected cells
     ${ctrl_or_cmd_name}+V:   paste selected cells
 
-    ${ctrl_or_cmd_name}+M:   toogle Markdown
+    ${ctrl_or_cmd_name}+M:   toggle markdown
 
     The notebook file saves every time you run a cell.`
                 )


### PR DESCRIPTION
Added the shortcut for toggling between code and markdown to the list.
I also completed the sentence "The notebook file saves every time you run" as it appears on https://github.com/fonsp/Pluto.jl/wiki/%F0%9F%92%BB--UI